### PR TITLE
Add adotop to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Want to add your additional [bubbles](https://github.com/charmbracelet/bubbles) 
 
 <!-- In alphabetical order, please -->
 
+- [adotop](https://github.com/superyyrrzz/adotop) - Terminal UI for Azure DevOps pull requests: browse, diff, comment, and approve from the terminal. (_built with Bubble Tea, Bubbles, Lip Gloss, Glamour, and Chroma_)
 - [AT CLI](https://github.com/daskycodes/at_cli) - Execute AT Commands via serial port connections. (_built with Bubble Tea_)
 - [CRT](https://github.com/BigJk/crt) - A simple terminal emulator for running Bubble Tea in a dedicated window, with optional shaders. (_built with Bubble Tea_)
 - [Glow](https://github.com/charmbracelet/glow) - A markdown reader, browser, and online markdown stash. (_built with Bubble Tea_)


### PR DESCRIPTION
Adds [adotop](https://github.com/superyyrrzz/adotop) to the Development Tools section — a TUI for Azure DevOps PR review, the ADO counterpart to gh-dash.

Features:
  * Browse PRs across Recents / Assigned / Created / Reviewing
  * Read diffs with syntax highlighting (uses local clone's `git diff` when available, falls back to a REST diff)
  * Walk threads inline under their target diff line
  * Compose comments in an in-TUI textarea (the diff stays visible while you type)
  * Per-commit diff view
  * Stale-approval detection from ADO's VoteUpdate thread events

README has a demo gif and the CONTRIBUTING.md screenshots/gif requirement is satisfied. Sorted alphabetically (lands at the top of Development Tools, above AT CLI).