### PR TITLE
Add tea-dash to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Want to add your additional [bubbles](https://github.com/charmbracelet/bubbles) 
 - [startpoint](https://github.com/susiteemu/startpoint) - A TUI/CLI tool for managing and scripting HTTP/RESTful requests. (_built with Bubble Tea_)
 - [sttr](https://github.com/abhimanyu003/sttr) - A general-purpose text transformer. (_built with Bubble Tea_)
 - [tapioca](https://github.com/charm-and-friends/tapioca) - Floating progress bar compatible with any loggers that you might use. (_built with Bubble Tea_)
+- [tea-dash](https://github.com/gbarany/tea-dash) - A gh-dash-style dashboard for Gitea and Forgejo: PRs, issues, notifications, and CI runs. (_built with Bubble Tea, Bubbles, Lip Gloss and Glamour_)
 - [TermiPOSTMAN](https://github.com/Suryakantdsa/TermiPOSTMAN) - A beautiful and intuitive Postman-like API testing tool — right in your terminal. (_built with Bubble Tea_)
 - [termpicker](https://github.com/ChausseBenjamin/termpicker) - A colorpicker for your terminal.
 - [trainer](https://github.com/rusinikita/trainer) - A Go concurrency coding interview simulator with learning materials. (_built with Bubble Tea_)


### PR DESCRIPTION
Adds [tea-dash](https://github.com/gbarany/tea-dash) — a gh-dash-style terminal dashboard for Gitea and Forgejo: PRs, issues, notifications, Actions runs, and local branches across one or more instances, with configurable sections and keyboard-driven actions.

**Charm libraries used:** Bubble Tea v2, Bubbles v2, Lip Gloss v2, and Glamour v2 (the v2 `charm.land` modules).

The README includes a VHS-recorded demo GIF, and there's a zero-setup demo mode: `tea-dash --mock`. Placed alphabetically in Development Tools. MIT, Go.