### PR TITLE
chore(readme): add showagent to AI applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Want to add your additional [bubbles](https://github.com/charmbracelet/bubbles) 
 - [clipt](https://github.com/Struki84/clipt) - Chat TUI go module for your agents and LLMs. (_built with Bubble Tea, Lip Gloss, Glamour_)
 - [mods](https://github.com/charmbracelet/mods) - AI on the CLI, built for pipelines. (_built with Bubble Tea_)
 - [Plandex](https://github.com/plandex-ai/plandex) - A terminal-based AI coding engine for complex tasks. (_built with Bubble Tea_)
+- [showagent](https://github.com/aytzey/showagent) - Browse, search, resume, branch, and convert local AI coding-agent sessions from one TUI. (_built with Bubbles, Bubble Tea and Lip Gloss_)
 - [tgpt](https://github.com/aandrew-me/tgpt) - Conversational AI for the CLI; no API keys necessary. (_built with Bubble Tea_)
 - [vyai](https://github.com/vybraan/vyai) - A lightweight CLI tool to interact with the Gemini API from the terminal.  (_built with Bubble Tea, Lip Gloss, Glamour_)
 


### PR DESCRIPTION
Adds [showagent](https://github.com/aytzey/showagent) to the AI section: a TUI that unifies the local session stores of Claude Code, Codex, Gemini CLI and OpenCode so you can browse, search, resume, branch, and convert coding-agent conversations between agents. I'm the author of showagent. Built with Bubbles v2, Bubble Tea v2 and Lip Gloss v2; the README includes a demo GIF recorded with vhs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)