### PR TITLE
chore(readme): add golazo to Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Want to add your additional [bubbles](https://github.com/charmbracelet/bubbles) 
 ### Media
 
 - [BatterUp](https://github.com/daltonsw/batterup) - A stylish (and discrete) way to monitor MLB games from your terminal. (_built with Bubble Tea_)
+- [Golazo](https://github.com/0xjuanma/golazo) - A minimalist TUI for following live and recent football/soccer matches. (_built with Bubble Tea, Bubbles, Lip Gloss_)
 - [sonicradio](https://github.com/dancnb/sonicradio) - A TUI radio player making use of Radio Browser API. (_built with Bubble Tea_)
 - [lazyspotify](https://github.com/dubeyKartikay/lazyspotify) - Terminal Spotify client for macOS and Linux. (_built with Bubble Tea, Lip Gloss_)
 - [tTune](https://github.com/SteveMCWin/ttune) - An aesthetic guitar tuner for your terminal. (built with Bubble Tea, Lip Gloss)


### PR DESCRIPTION
## Summary
Adds [Golazo](https://github.com/0xjuanma/golazo), a Bubble Tea-based TUI for following live and recent football/soccer matches, to the Media section.


<img width="1000" height="700" alt="golazo-demo" src="https://github.com/user-attachments/assets/d98fbc38-85f5-40ac-a4a8-b75414077bbd" />
