### PR TITLE
Add Waveloom to AI applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Want to add your additional [bubbles](https://github.com/charmbracelet/bubbles) 
 - [Plandex](https://github.com/plandex-ai/plandex) - A terminal-based AI coding engine for complex tasks. (_built with Bubble Tea_)
 - [tgpt](https://github.com/aandrew-me/tgpt) - Conversational AI for the CLI; no API keys necessary. (_built with Bubble Tea_)
 - [vyai](https://github.com/vybraan/vyai) - A lightweight CLI tool to interact with the Gemini API from the terminal.  (_built with Bubble Tea, Lip Gloss, Glamour_)
+- [Waveloom](https://github.com/Menfre01/waveloom) - A DeepSeek-native terminal coding agent with prefix-cache architecture, Think-Act-Observe loop, and Claude Code-level TUI. (_built with Bubble Tea, Glamour, and Lip Gloss_)
 
 ### Cloud and DevOps
 


### PR DESCRIPTION
## Description

Add [Waveloom](https://github.com/Menfre01/waveloom) to the AI applications section.

Waveloom is a DeepSeek-native terminal coding agent written in Go, built on the Charm stack:

- **Bubble Tea** — Full TUI with streaming reasoning, rich diff, permission dialogs
- **Glamour** — Markdown rendering for LLM responses
- **Lip Gloss** — Terminal styling and theming (light/dark/color-blind)

The project meets the [contribution requirements](https://github.com/charm-and-friends/charm-in-the-wild/blob/main/CONTRIBUTING.md):
- ✅ Implements MVP (available via Homebrew and curl installer)
- ✅ README includes a demo GIF
- ✅ Entry lists all Charm libraries used