### PR TITLE
Update rig.fm description to mention track identification

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Want to add your additional [bubbles](https://github.com/charmbracelet/bubbles) 
 - [lazyspotify](https://github.com/dubeyKartikay/lazyspotify) - Terminal Spotify client for macOS and Linux. (_built with Bubble Tea, Lip Gloss_)
 - [tTune](https://github.com/SteveMCWin/ttune) - An aesthetic guitar tuner for your terminal. (built with Bubble Tea, Lip Gloss)
 - [Waves](https://github.com/llehouerou/waves) - Terminal music player with library browsing, queue management, and Soulseek integration. (_built with Bubble Tea, Lip Gloss_)
-- [rig.fm](https://github.com/MWhyte/rig) - Internet radio in your terminal. Browse, search, and listen to thousands of stations. (_built with
+- [rig.fm](https://github.com/MWhyte/rig) - Internet radio in your terminal, with one-keypress Shazam-style track identification. (_built with
   Bubble Tea, Bubbles, Lip Gloss_)
 
 


### PR DESCRIPTION
Small description update to an existing entry in Media.

rig.fm was added back in April (#87). Since then it has gained Shazam-style track identification: press `i` while a station is playing and it fingerprints the audio locally in pure Go, no API key needed. That is the most distinctive thing it does now, so the entry is worth refreshing to reflect it.

No new entry, no change to the built-with list.