### PR TITLE
Add nastro to Productivity and Organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ Want to add your additional [bubbles](https://github.com/charmbracelet/bubbles) 
 - [togo](https://github.com/prime-run/togo) - A fast, simple and beautifull termianl-based todo manager built in go. (_built with Bubble Tea_)
 - [Tudo](https://github.com/FiyZou/tudo) - A foreground todo TUI for keeping notes while working in Codex CLI or CC CLI. (_built with Bubble Tea, Bubbles and Lip Gloss_)
 - [NaSC](https://github.com/parnoldx/nascTUI) - A TUI calculator where you do maths like a normal person. (_built with Bubble Tea_)
+- [nastro](https://github.com/scaccogatto/nastro) - Terminal call recorder for macOS: records system audio + mic (no bot joins the call), transcribes on-device with speaker diarization. TUI + headless CLI. (_built with Bubble Tea_)
 
 ### RSS, News and Weather
 


### PR DESCRIPTION
nastro is a terminal call recorder for macOS: it captures system audio + mic locally (no bot joins the call) and transcribes on-device with speaker diarization. Ships as both a TUI and a headless CLI.

Good fit for the list: the TUI is built with Bubble Tea, and it doubles as an example of pairing a Bubble Tea interface with a headless CLI mode for the same core tool.

Demo: https://github.com/scaccogatto/nastro/blob/main/.github/demo.gif

Repo: https://github.com/scaccogatto/nastro (MIT)

Disclosure: I'm the author, self-submitting per the repo's contribution guidelines.