### PR TITLE
Add agent-manager to Applications / AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Want to add your additional [bubbles](https://github.com/charmbracelet/bubbles) 
 
 <!-- In alphabetical order, please -->
 
+- [agent-manager](https://github.com/YoanWai/agent-manager) - tmux TUI for Claude Code, Codex, OpenCode, Grok, Gemini CLI, and Pi: live status, a prompt without attaching, and in-terminal diff review. (_built with Bubbles, Bubble Tea and Lip Gloss_)
 - [agenttrace](https://github.com/luoyuctl/agenttrace) - TUI observability for AI coding-agent sessions. (_built with Bubbles, Bubble Tea and Lip Gloss_)
 - [ChatGPTUI](https://github.com/dwisiswant0/chatgptui) - A TUI for ChatGPT. (_built with Bubble Tea_)
 - [clawchat-cli](https://github.com/ngmaloney/clawchat-cli) - A CLI chat client for OpenClaw Gateway and Ollama models. (_built with Bubble Tea and Lip Gloss_)


### PR DESCRIPTION
agent-manager is a tmux TUI for running Claude Code, Codex, OpenCode, Grok, Gemini CLI, Pi, and Hermes side by side. Live status in one list, a prompt that lands in a pane without attaching, and in-terminal full-file diff review with line comments sent back to the agent.

Charm libraries used: [Bubbles](https://github.com/charmbracelet/bubbles), [Bubble Tea](https://github.com/charmbracelet/bubbletea), [Lip Gloss](https://github.com/charmbracelet/lipgloss). README has screenshots and GIFs.

https://github.com/YoanWai/agent-manager