### PR TITLE
Add bermuda

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Want to add your additional [bubbles](https://github.com/charmbracelet/bubbles) 
 
 - [agent-manager](https://github.com/YoanWai/agent-manager) - tmux TUI for Claude Code, Codex, OpenCode, Grok, Gemini CLI, and Pi: live status, a prompt without attaching, and in-terminal diff review. (_built with Bubbles, Bubble Tea and Lip Gloss_)
 - [agenttrace](https://github.com/luoyuctl/agenttrace) - TUI observability for AI coding-agent sessions. (_built with Bubbles, Bubble Tea and Lip Gloss_)
+- [bermuda](https://github.com/bon5co/bermuda) - Orchestration harness beneath Claude Code on the herdr terminal multiplexer: schedules agent jobs on a cron, runs declared flows a step of which can't be skipped, and gives agents a shared thread/claim/forum layer. (_built with Bubbles, Bubble Tea and Lip Gloss_)
 - [ChatGPTUI](https://github.com/dwisiswant0/chatgptui) - A TUI for ChatGPT. (_built with Bubble Tea_)
 - [clawchat-cli](https://github.com/ngmaloney/clawchat-cli) - A CLI chat client for OpenClaw Gateway and Ollama models. (_built with Bubble Tea and Lip Gloss_)
 - [chatgpt-cli](https://github.com/j178/chatgpt) - A CLI for ChatGPT. (_built with Bubble Tea_)


### PR DESCRIPTION
Adds [bermuda](https://github.com/bon5co/bermuda) to the AI section.

bermuda is an orchestration harness that sits beneath Claude Code on the herdr terminal multiplexer: it schedules agent jobs on a cron, runs declared multi-step flows whose steps an agent cannot skip, and gives agents a shared thread/claim/forum/memory layer. Its board (jobs, runs, flows, threads tabs) is built with Bubble Tea, Bubbles, and Lip Gloss.

MIT licensed, MVP-complete and in daily use on the author's own machine (see the README's "Status, and what to trust" section for an honest account of maturity).